### PR TITLE
In cooperation Manuel @donnerbrenn: LD_LIBRARY_PATH order fixed.

### DIFF
--- a/smol/parse.py
+++ b/smol/parse.py
@@ -152,8 +152,10 @@ def get_needed_syms(readelf_bin, inpfile) -> Dict[str, str]: # (symname, relocty
 def format_cc_path_line(entry):
     category, path = entry.split(': ', 1)
     path = path.lstrip('=')
-    return (category, list(set(os.path.realpath(p) \
-        for p in path.split(':') if os.path.isdir(p))))
+    paths = list(os.path.realpath(p) \
+                 for p in path.split(':') if os.path.isdir(p))
+    paths.reverse() # order of $LD_LIBRARY_PATH
+    return (category, list(paths))
 
 
 def get_cc_paths(cc_bin):


### PR DESCRIPTION
The order of members in the `spaths` variable were random, due to the construction with `set()` datatype, which is unordered.  The order now should be the same as the reversed output of the request CC_PATH_LINE.